### PR TITLE
Update server.ts. Pass host option to fastify

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -66,7 +66,7 @@ export async function startServer(options: CliOptions) {
     await checkOllamaVersion(options);
     await startOllamaServer(options);
     await checkOllamaModels(options);
-    await app.listen({ port: options.port });
+    await app.listen({ port: options.port, host: options.host });
 
     console.log(`Azure OpenAI emulator started on http://${options.host}:${options.port}`);
     console.log('Press CTRL+C to quit.');


### PR DESCRIPTION
Since host is not being passed to fastify it alwyas opens spawns server on localhost which wont be accessible from other machines on network. Passing 0.0.0.0 as host allows connection from other networks.